### PR TITLE
:arrow_up: Updating version of nuxtjs/eslint-config

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@babel/runtime-corejs2": "^7.7.7",
-    "@nuxtjs/eslint-config": "^1.0.1",
+    "@nuxtjs/eslint-config": "^2.0.0",
     "@nuxtjs/eslint-module": "^1.0.0",
     "@vue/test-utils": "^1.0.0-beta.27",
     "babel-eslint": "^10.0.1",


### PR DESCRIPTION
The linter needed updating as it was not compatible with newer versions of Vue syntax.
(https://github.com/nuxt/eslint-plugin-nuxt/issues/65)